### PR TITLE
adding mapped phenotypes for CHARGE syndrome

### DIFF
--- a/mappings/mp_hp_mgi_all.sssom.tsv
+++ b/mappings/mp_hp_mgi_all.sssom.tsv
@@ -1000,3 +1000,366 @@ HP:0100716	Self-injurious behavior	skos:narrowMatch	1	MP:0005655	increased aggre
 HP:0100864	Short femoral neck	skos:exactMatch	1	MP:0030793	short femur neck	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	CdL4	
 HP:0100874	Thick hair	skos:narrowMatch	1	MP:0002073	abnormal hair growth	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	CdL3	
 HP:0200055	Small hand	skos:narrowMatch	1	MP:0000572	abnormal autopod morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	"CdL, CDL2, 3, 5 | ticket #3781"
+HP:0011454	Abnormality of the malleus	skos:exactMatch	0.9	MP:0000029	abnormal malleus morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-02	Chd7| HPO term does not specify morphology in definition or eq but lives on the morphology branch so I called this exact
+HP:0000375	Abnormal cochlea morphology	skos:exactMatch	1	MP:0000031	abnormal cochlea morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-02	Chd7
+HP:0011376	Morphological abnormality of the vestibule of the inner ear	skos:exactMatch	1	MP:0000034	abnormal inner ear vestibule morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-02	Chd7
+HP:0011390	Morphological abnormality of the inner ear	skos:broadMatch	1	MP:0000039	abnormal otic capsule morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-02	Chd7
+HP:0001627	Abnormal heart morphology	skos:broadMatch	1	MP:0000267	abnormal heart development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7
+HP:0001713	Abnormal cardiac ventricle morphology	skos:broadMatch	1	MP:0000280	thin ventricular wall	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7
+HP:0001627	Abnormal heart morphology	skos:broadMatch	1	MP:0000297	abnormal atrioventricular cushion morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7
+HP:0031377	Abnormal cell proliferation	skos:broadMatch	1	MP:0000352	decreased cell proliferation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7
+HP:0000234	Abnormality of the head	skos:exactMatch	0.9	MP:0000428	abnormal craniofacial morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	CHARGE model not Chd7| some uncertainty based on differences in children but I think these are more likely oversites then intended differences
+HP:0000271	Abnormality of the face	skos:broadMatch	1	MP:0000446	long snout	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7
+HP:0030966	Abnormal pulmonary artery morphology	skos:broadMatch	1	MP:0000486	abnormal pulmonary trunk morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7
+HP:0002814	Abnormality of the lower limb	skos:exactMatch	1	MP:0000556	abnormal hindlimb morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7| ticket #3803
+HP:0000778	Hypoplasia of the thymus	skos:closeMatch	0.9	MP:0000706	small thymus	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	"Chd7| HPO uses hypoplasia and small as synonyms, MP distinguishes between these but I think the majority of the time MP small = HP hypoplasia"
+HP:0001273	Abnormal corpus callosum morphology	skos:exactMatch	1	MP:0000780	abnormal corpus callosum morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-04	Chd7
+HP:0100547	Abnormal forebrain morphology	skos:broadMatch	1	MP:0000787	abnormal telencephalon morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0002060	Abnormal cerebral morphology	skos:narrowMatch	1	MP:0000787	abnormal telencephalon morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	"Chd7| HPO uses telencephalon as a synonym of cerebrum but the MP has this defined as 'consists of the paired cerebral hemispheres and olfactory bulbs, the basal ganglia and the connecting structure'"
+HP:0002060	Abnormal cerebral morphology	skos:broadMatch	1	MP:0000794	abnormal parietal lobe morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0002538	Abnormal cerebral cortex morphology	skos:broadMatch	1	MP:0000798	abnormal frontal lobe morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0007333	Hypoplasia of the frontal lobes	skos:narrowMatch	1	MP:0000798	abnormal frontal lobe morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	
+HP:0025100	Abnormal hippocampus morphology	skos:exactMatch	1	MP:0000807	abnormal hippocampus morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0025100	Abnormal hippocampus morphology	skos:broadMatch	1	MP:0000809	absent hippocampus	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0025057	Abnormality of olfactory lobe morphology	skos:exactMatch	1	MP:0000819	abnormal olfactory bulb morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0006956	Lateral ventricle dilatation	skos:exactMatch	1	MP:0000825	dilated lateral ventricle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0007082	Dilated third ventricle	skos:exactMatch	1	MP:0000827	dilated third ventricle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0001317	Abnormal cerebellum morphology	skos:broadMatch	1	MP:0000857	abnormal cerebellar foliation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0001317	Abnormal cerebellum morphology	skos:broadMatch	1	MP:0000877	abnormal Purkinje cell morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0001317	Abnormal cerebellum morphology	skos:broadMatch	1	MP:0000880	decreased Purkinje cell number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0012443	Abnormality of brain morphology	skos:broadMatch	1	MP:0000913	abnormal brain development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	Chd7
+HP:0030769	Exencephaly	skos:closeMatch	0.8	MP:0000914	exencephaly	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-16	"CHARGE model not Chd7| need to discuss, MP has this under brain development and defined as ""neurocranial defects resulting in exposure or extrusion of the brain"" HPO has under neural tube defects and defined as ""A malformation of the neural tube with a large amount of protruding brain tissue and absence of calvarium."""
+HP:0100547	Abnormal forebrain morphology	skos:broadMatch	1	MP:0000934	abnormal telencephalon development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0100705	Abnormal glial cell morphology	skos:broadMatch	0.8	MP:0000952	abnormal CNS glial cell morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	"Chd7| calling this broad based on the text and eq, but based on location in the HPO these would be exact"
+HP:0100705	Abnormal glial cell morphology	skos:broadMatch	1	MP:0000953	abnormal oligodendrocyte morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0012639	Abnormal nervous system morphology	skos:broadMatch	1	MP:0000968	abnormal sensory neuron innervation pattern	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0001291	Abnormal cranial nerve morphology	skos:exactMatch	1	MP:0001056	abnormal cranial nerve morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0010827	Abnormality of the seventh cranial nerve	skos:closeMatch	0.9	MP:0001071	abnormal facial nerve morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	CHARGE model not Chd7
+HP:0001291	Abnormal cranial nerve morphology	skos:broadMatch	1	MP:0001074	abnormal vagus nerve morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0410016	Abnormal cranial ganglion morphology	skos:broadMatch	1	MP:0001092	abnormal trigeminal ganglion morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0008724	Hypoplasia of the ovary	skos:closeMatch	1	MP:0001127	small ovary	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0031065	Abnormal ovarian morphology	skos:broadMatch	1	MP:0001129	impaired ovarian folliculogenesis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0000022 	Abnormal male internal genitalia morphology	skos:broadMatch	1	MP:0001157	small seminal vesicle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	CHARGE model not Chd7
+HP:0012372	Abnormal eye morphology	skos:broadMatch	1	MP:0001286	abnormal eye development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0012376	Microphakia	skos:exactMatch	1	MP:0001306	small lens	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7| MP puts spherophakia under small lens but HPO has this as a sibling 
+HP:0000615	Abnormal pupil morphology	skos:exactMatch	0.9	MP:0001317	abnormal pupil morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7| label is morphology but definition is less specific 
+HP:0012433	Abnormal social behavior	skos:broadMatch	1	MP:0001386	abnormal maternal nurturing	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0100022	Abnormality of movement	skos:broadMatch	1	MP:0001388	abnormal stationary movement	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:5200069	Spinning	skos:relatedMatch	0.9	MP:0001395	bidirectional circling	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	Chd7
+HP:0002275	Poor motor coordination	skos:exactMatch	0.9	MP:0001405	impaired coordination	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	"Chd7| MP term lives under behavior HPO is under nervous system, most of the MP annotations are for balance related assays while the HPO term has a child of fine motor coordination which may result in some mismatch between the terms in practice"
+HP:0002457	Abnormal head movements	skos:broadMatch	1	MP:0001410	head bobbing	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0002071	Abnormality of extrapyramidal motor function	skos:broadMatch	0.9	MP:0001489	decreased startle reflex	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7| mapping based primarily on the HPO term being a parent of Exaggerated startle response
+HP:0025403	Stooped posture	skos:relatedMatch	0.9	MP:0001512	trunk curl	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0011443	Abnormality of coordination	skos:exactMatch	1	MP:0001516	abnormal motor coordination/balance	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0007015	Poor gross motor coordination	skos:broadMatch	1	MP:0001522	impaired swimming	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0002275	Poor motor coordination	skos:broadMatch	1	MP:0001523	impaired righting response	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0011443	Abnormality of coordination	skos:broadMatch	1	MP:0001526	abnormal placing response	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0012379	Abnormal circulating enzyme concentration or activity	skos:broadMatch	1	MP:0001570	abnormal circulating enzyme level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0033353	Abnormal blood vessel morphology	skos:exactMatch	1	MP:0001614	abnormal blood vessel morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	CHARGE model not Chd7
+HP:0000969	Edema	skos:exactMatch	1	MP:0001785	edema	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0000388	Otitis media	skos:relatedMatch	1	MP:0001850	increased susceptibility to otitis media	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0000509	Conjunctivitis	skos:exactMatch	1	MP:0001852	conjunctivitis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0011029	Internal hemorrhage	skos:narrowMatch	1	MP:0001914	hemorrhage	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0000144	Decreased fertility	skos:broadMatch	1	MP:0001921	reduced fertility	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7| MP has infertility as a sibling of reduced fertility but HP has infertility as a child making these not exact matches 
+HP:0012041	Decreased fertility in males	skos:broadMatch	1	MP:0001922	reduced male fertility	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0000868	Decreased fertility in females	skos:broadMatch	1	MP:0001923	reduced female fertility	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0000140	Abnormality of the menstrual cycle	skos:relatedMatch	1	MP:0001927	abnormal estrous cycle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0008734	Decreased testicular size	skos:broadMatch	1	MP:0001940	testis hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0010829	Impaired temperature sensation	skos:relatedMatch	1	MP:0001973	increased thermal nociceptive threshold	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0004408	Abnormality of the sense of smell	skos:narrowMatch	1	MP:0001983	abnormal olfactory system physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0012639	Abnormal nervous system morphology	skos:broadMatch	1	MP:0002184	abnormal innervation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0030681	Abnormal morphology of myocardial trabeculae	skos:exactMatch	1	MP:0002189	abnormal myocardial trabeculae morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-17	Chd7
+HP:0000035	Abnormal testis morphology	skos:broadMatch	1	MP:0002216	abnormal seminiferous tubule morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0005288	Abnormal nostril morphology	skos:broadMatch	1	MP:0002236	abnormal internal nares morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0033151	Abnormal pharynx morphology	skos:broadMatch	1	MP:0002252	abnormal oropharynx morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	CHARGE model not Chd7
+HP:0011380	Morphological abnormality of the semicircular canal	skos:exactMatch	1	MP:0002428	abnormal semicircular canal morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0000375	Abnormal cochlea morphology	skos:broadMatch	1	MP:0002622	abnormal cochlear hair cell morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0001660	Truncus arteriosus	skos:exactMatch	1	MP:0002633	persistent truncus arteriosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	CHARGE model not Chd7
+HP:0000823	Delayed puberty	skos:relatedMatch	1	MP:0002636	delayed vaginal opening	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0012153	Hypotriglyceridemia	skos:exactMatch	1	MP:0002644	decreased circulating triglyceride level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0001637	Abnormal myocardium morphology	skos:broadMatch	1	MP:0002652	thin myocardium	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0010948	Abnormal fetal cardiovascular morphology	skos:broadMatch	1	MP:0002672	abnormal pharyngeal arch artery morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0000823	Delayed puberty	skos:relatedMatch	1	MP:0002683	delayed fertility	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040299	Decreased circulating free fatty acid level	skos:exactMatch	1	MP:0002702	decreased circulating free fatty acids level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040216	Hypoinsulinemia	skos:exactMatch	1	MP:0002727	decreased circulating insulin level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0002457	Abnormal head movements	skos:broadMatch	1	MP:0002730	head shaking	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040326	Hypoplasia of the olfactory bulb	skos:closeMatch	1	MP:0002741	small olfactory bulb	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0002762	ectopic cerebellar granule cells	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0030344	Decreased circulating luteinizing hormone level	skos:exactMatch	1	MP:0002773	decreased circulating luteinizing hormone level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0030341	Decreased circulating follicle stimulating hormone concentration	skos:exactMatch	1	MP:0002790	decreased circulating follicle stimulating hormone level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0001640	Cardiomegaly	skos:broadMatch	1	MP:0002833	increased heart weight	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	CHARGE model not Chd7
+HP:0040107	Morphological abnormality of the posterior semicircular canal	skos:exactMatch	1	MP:0002858	abnormal posterior semicircular canal morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0011384	Abnormality of the internal auditory canal	skos:broadMatch	1	MP:0002859	abnormal inner ear canal fusion	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0012379	Abnormal circulating enzyme concentration or activity	skos:broadMatch	1	MP:0002942	decreased circulating alanine transaminase level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0000089	Renal hypoplasia	skos:closeMatch	1	MP:0002989	small kidney	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	CHARGE model not Chd7
+HP:0010517	Ectopic thymus tissue	skos:exactMatch	1	MP:0003007	ectopic thymus	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040108	Morphological abnormality of the anterior semicircular canal	skos:exactMatch	1	MP:0003069	abnormal superior semicircular canal morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0000055	Abnormality of female external genitalia	skos:exactMatch	0.9	MP:0003126	abnormal external female genitalia morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0000375	Abnormal cochlea morphology	skos:broadMatch	1	MP:0003148	decreased cochlear coiling	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040106	Morphological abnormality of the lateral semicircular canal	skos:broadMatch	1	MP:0003161	absent lateral semicircular canal	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0011381	Aplasia of the semicircular canal	skos:broadMatch	1	MP:0003161	absent lateral semicircular canal	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040106	Morphological abnormality of the lateral semicircular canal	skos:broadMatch	1	MP:0003162	decreased lateral semicircular canal size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0011381	Aplasia of the semicircular canal	skos:broadMatch	1	MP:0003163	absent posterior semicircular canal	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040107	Morphological abnormality of the posterior semicircular canal	skos:broadMatch	1	MP:0003163	absent posterior semicircular canal	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040107	Morphological abnormality of the posterior semicircular canal	skos:broadMatch	1	MP:0003164	decreased posterior semicircular canal size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040108	Morphological abnormality of the anterior semicircular canal	skos:broadMatch	1	MP:0003166	decreased superior semicircular canal size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0002529	Neuronal loss in central nervous system	skos:relatedMatch	1	MP:0003203	increased neuron apoptosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:4000056	Abnormal apoptosis	skos:broadMatch	1	MP:0003222	increased cardiomyocyte apoptosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0040115	Abnormal Eustachian tube morphology	skos:exactMatch	1	MP:0003330	abnormal auditory tube morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0031251	Abnormal subclavian artery morphology	skos:exactMatch	1	MP:0003395	abnormal subclavian artery morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0031794	Decreased circulating glycerol level	skos:exactMatch	1	MP:0003442	decreased circulating glycerol level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0032466	Aplasia of the olfactory bulb	skos:closeMatch	1	MP:0003451	absent olfactory bulb	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0410016	Abnormal cranial ganglion morphology	skos:broadMatch	1	MP:0003703	abnormal vestibulocochlear ganglion morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0003103	Abnormal cortical bone morphology	skos:exactMatch	1	MP:0003797	abnormal compact bone morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0031703	Abnormal ear morphology	skos:broadMatch	1	MP:0003938	abnormal ear development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0003119	Abnormal circulating lipid concentration	skos:exactMatch	1	MP:0003949	abnormal circulating lipid level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0001511	Intrauterine growth retardation	skos:broadMatch	1	MP:0003984	embryonic growth retardation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0033334	Abnormal embryonic development	skos:broadMatch	1	MP:0004188	delayed embryo turning	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-22	Chd7
+HP:0011380	Morphological abnormality of the semicircular canal	skos:broadMatch	1	MP:0004249	abnormal crista ampullaris morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0410043	Abnormal neural tube morphology	skos:broadMatch	1	MP:0004261	abnormal embryonic neuroepithelium morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0012372	Abnormal eye morphology	skos:broadMatch	1	MP:0004269	abnormal optic cup morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0008628	Abnormality of the stapes	skos:broadMatch	1	MP:0004290	abnormal stapes footplate morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0000359	Abnormality of the inner ear	skos:broadMatch	1	MP:0004310	small otic vesicle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0030999	Abnormal vestibular saccule morphology	skos:broadMatch	1	MP:0004315	absent vestibular saccule	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0040109	Morphological abnormality of the utricle	skos:broadMatch	1	MP:0004369	absent utricle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0000375	Abnormal cochlea morphology	skos:broadMatch	1	MP:0004395	increased cochlear inner hair cell number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0000375	Abnormal cochlea morphology	skos:broadMatch	1	MP:0004401	increased cochlear outer hair cell number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0011380	Morphological abnormality of the semicircular canal	skos:broadMatch	1	MP:0004409	abnormal crista ampullaris neuroepithelium morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0011389	Functional abnormality of the inner ear	skos:broadMatch	1	MP:0004413	absent cochlear microphonics	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0011389	Functional abnormality of the inner ear	skos:broadMatch	1	MP:0004417	decreased cochlear nerve compound action potential	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0040100	Abnormality of the vestibular window	skos:exactMatch	1	MP:0004479	abnormal oval window morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0040099	Abnormality of the round window	skos:exactMatch	1	MP:0004480	abnormal round window morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:3000047	Abnormal glossopharyngeal nerve morphology	skos:broadMatch	1	MP:0004568	fusion of glossopharyngeal and vagus nerve	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0030305	Decreased number of vertebrae	skos:broadMatch	1	MP:0004647	decreased lumbar vertebrae number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0011392	Abnormality of the vestibular nerve	skos:exactMatch	0.9	MP:0004718	abnormal vestibular nerve morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7| some doubt as the HPO term lacks a definition
+HP:0011389	Functional abnormality of the inner ear	skos:broadMatch	1	MP:0004736	abnormal distortion product otoacoustic emission	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0011389	Functional abnormality of the inner ear	skos:broadMatch	1	MP:0004737	absent distortion product otoacoustic emissions	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0012638	Abnormal nervous system physiology	skos:broadMatch	1	MP:0004811	abnormal neuron physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0008734	Decreased testicular size	skos:broadMatch	1	MP:0004852	decreased testis weight	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0008724	Hypoplasia of the ovary	skos:broadMatch	1	MP:0004856	decreased ovary weight	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0000362	Otosclerosis	skos:exactMatch	1	MP:0004897	otosclerosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0011380	Morphological abnormality of the semicircular canal	skos:broadMatch	1	MP:0004922	abnormal common crus morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0000364	Hearing abnormality	skos:broadMatch	1	MP:0004925	decreased susceptibility to noise-induced hearing loss	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0004452	Abnormality of the middle ear ossicles	skos:exactMatch	0.9	MP:0005105	abnormal middle ear ossicle morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7| some uncertainty as the HPO term while on the morphology branch does not specify morphology in the definition
+HP:0011453	Abnormality of the incus	skos:exactMatch	0.9	MP:0005106	abnormal incus morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7| some uncertainty as the HPO term while on the morphology branch does not specify morphology in the definition
+HP:0005599	Hypopigmentation of hair	skos:broadMatch	1	MP:0005171	absent coat pigmentation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	CHARGE model not Chd7
+HP:0003146	Hypocholesterolemia	skos:exactMatch	1	MP:0005179	decreased circulating cholesterol level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0002457	Abnormal head movements	skos:broadMatch	1	MP:0005191	head tilt	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0045025	Narrow palpebral fissure	skos:exactMatch	1	MP:0005287	narrow eye opening	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-23	Chd7
+HP:0001952	Glucose intolerance	skos:narrowMatch	1	MP:0005291	abnormal glucose tolerance	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7|while this has the synonym 'abnormal glucose tolerance' the MP term has both improved and impaired children so this is not an exact match
+HP:0002457	Abnormal head movements	skos:broadMatch	1	MP:0005307	head tossing	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0002457	Abnormality of metabolism/homeostasis	skos:narrowMatch	0.9	MP:0005376	homeostasis/metabolism phenotype	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	"Chd7|some uncertainty due to differences in child terms, narrow since MP is not explicity abnormal"
+HP:0000598	Abnormality of the ear	skos:narrowMatch	1	MP:0005377	hearing/vestibular/ear phenotype	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0000818	Abnormality of the endocrine system	skos:narrowMatch	1	MP:0005379	endocrine/exocrine gland phenotype	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0001197	Abnormality of prenatal development or birth	skos:closeMatch	0.9	MP:0005380	embryo phenotype	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0011446	Abnormality of higher mental function	skos:narrowMatch	1	MP:0005386	behavior/neurological phenotype	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0000478	Abnormality of the eye	skos:narrowMatch	1	MP:0005391	vision/eye phenotype	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0010876	Abnormal circulating protein concentration	skos:exactMatch	1	MP:0005416	abnormal circulating protein level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0041079	Decreased body fat percentage	skos:exactMatch	1	MP:0005459	decreased percent body fat/body weight	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0000517	Abnormal lens morphology	skos:broadMatch	1	MP:0005545	abnormal lens development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-24	Chd7
+HP:0003075	Hypoproteinemia	skos:closeMatch	0.9	MP:0005567	decreased circulating total protein level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-29	Chd7|called close as looking this up it seems like HPO terms is all proteins but the definition is not entirely clear
+HP:0002900	Hypokalemia	skos:closeMatch	0.9	MP:0005628	decreased circulating potassium level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-29	Chd7|MP has a seperate term for Hypokalemia that is a child of this term and one for erythrocyte levels specifically 
+HP:0012379	Abnormal circulating enzyme concentration or activity	skos:broadMatch	1	MP:0005632	decreased circulating aspartate transaminase level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-29	Chd7
+HP:0012285	Abnormal hypothalamus physiology	skos:exactMatch	1	MP:0005645	abnormal hypothalamus physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-29	Chd7
+HP:0012638	Abnormal nervous system physiology	skos:broadMatch	1	MP:0005646	abnormal pituitary gland physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-29	Chd7
+HP:0012245	Sex reversal	skos:exactMatch	1	MP:0005652	sex reversal	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	CHARGE model not Chd7
+HP:0031703	Abnormal ear morphology	skos:broadMatch	1	MP:0006030	abnormal otic vesicle development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:4000056	Abnormal apoptosis	skos:broadMatch	1	MP:0006042	increased apoptosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	CHARGE model not Chd7
+HP:4000056	Abnormal apoptosis	skos:broadMatch	1	MP:0006043	decreased apoptosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0012757	Abnormal neuron morphology	skos:broadMatch	1	MP:0006092	abnormal olfactory sensory neuron morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0011297	Abnormal digit morphology	skos:broadMatch	1	MP:0006280	abnormal digit development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0012372	Abnormal eye morphology	skos:broadMatch	1	MP:0006305	abnormal optic eminence morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0010948	Abnormal fetal cardiovascular morphology	skos:broadMatch	1	MP:0006354	abnormal fourth pharyngeal arch artery morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0010948	Abnormal fetal cardiovascular morphology	skos:broadMatch	1	MP:0006355	abnormal sixth pharyngeal arch artery morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0003111	Abnormal blood ion concentration	skos:narrowMatch	1	MP:0006357	abnormal circulating mineral level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0005930	Abnormal epiphysis morphology	skos:broadMatch	1	MP:0006396	decreased long bone epiphyseal plate size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0040218	Reduced natural killer cell count	skos:broadMatch	1	MP:0008039	increased NK T cell number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0011376	Morphological abnormality of the vestibule of the inner ear	skos:broadMatch	1	MP:0008066	small endolymphatic duct	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0025517	Hypoplastic hippocampus	skos:narrowMatch	1	MP:0008283	small hippocampus	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0011454	Abnormality of the malleus	skos:broadMatch	1	MP:0008374	abnormal malleus manubrium morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0000479	Abnormal retinal morphology	skos:broadMatch	1	MP:0008446	decreased retina cone cell number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0000479	Abnormal retinal morphology	skos:broadMatch	1	MP:0008449	abnormal retina cone cell outer segment morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0000479	Abnormal retinal morphology	skos:broadMatch	1	MP:0008456	abnormal retina rod cell outer segment morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0007082	Dilated third ventricle	skos:exactMatch	0.9	MP:0008536	enlarged third ventricle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	"Chd7| some uncertainty as the MP has a separate term for dilated third ventricle but the definition of the HP term is ""An increase in size of the third ventricle"" so I think these are exact matches"
+HP:0002538	Abnormal cerebral cortex morphology	skos:broadMatch	1	MP:0008547	abnormal neocortex morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0031295	Left atrial enlargement	skos:narrowMatch	1	MP:0008725	enlarged heart atrium	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	CHARGE model not Chd7
+HP:0030718	Right atrial enlargement	skos:narrowMatch	1	MP:0008725	enlarged heart atrium	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	
+HP:0005105	Abnormal nasal morphology	skos:broadMatch	1	MP:0008789	abnormal olfactory epithelium morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0002149	Hyperuricemia	skos:exactMatch	1	MP:0008821	increased blood uric acid level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0007485	Absence of subcutaneous fat	skos:exactMatch	1	MP:0008843	absent subcutaneous adipose tissue	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	CHARGE model not Chd7
+HP:0003758	Reduced subcutaneous adipose tissue	skos:exactMatch	1	MP:0008844	decreased subcutaneous adipose tissue amount	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	CHARGE model not Chd7
+HP:0012638	Abnormal nervous system physiology	skos:broadMatch	1	MP:0008917	abnormal oligodendrocyte physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0008924	decreased cerebellar granule cell number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0012757	Abnormal neuron morphology	skos:broadMatch	1	MP:0008946	abnormal neuron number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0012757	Abnormal neuron morphology	skos:broadMatch	1	MP:0008947	increased neuron number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0012757	Abnormal neuron morphology	skos:broadMatch	1	MP:0008948	decreased neuron number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0002795	Abnormal respiratory system physiology	skos:broadMatch	1	MP:0008963	increased carbon dioxide production	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0012569	Delayed menarche	skos:relatedMatch	1	MP:0009008	delayed estrous cycle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0034967	Uterine cyst	skos:exactMatch	1	MP:0009082	uterus cyst	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	CHARGE model not Chd7
+HP:0031105	Abnormal uterus morphology	skos:broadMatch	1	MP:0009085	abnormal uterine horn morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	Chd7
+HP:0040298	Hyperplasia of the endometrium	skos:exactMatch	1	MP:0009092	endometrium hyperplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-30	CHARGE model not Chd7
+HP:0040254	Decreased size of the clitoris	skos:broadMatch	1	MP:0009101	clitoris hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-31	Chd7
+HP:0011751	Abnormal posterior pituitary morphogenesis	skos:closeMatch	0.8	MP:0009229	abnormal neurohypophysis median eminence morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-31	"Chd7| uncertainty as the HPO term label is morphogenesis which implies development but the definition is just generic abnormality so there is a possibility that this could include both morphology and physiology, term potentially could be narrower or broader than the MP term"
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0009267	abnormal cerebellum fissure morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-31	Chd7
+HP:0001871	Abnormality of blood and blood-forming tissues	skos:broadMatch	1	MP:0009278	abnormal bone marrow cell physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-31	Chd7
+HP:0100705	Abnormal glial cell morphology	skos:broadMatch	1	MP:0009808	decreased oligodendrocyte number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-31	Chd7
+HP:0000175	Cleft palate	skos:closeMatch	0.8	MP:0009890	cleft secondary palate	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-31	"Chd7| uncertainty as the HPO term just specifies palate in general but the eq uses secondary palate, calling these close instead of exact due to this uncertainty"
+HP:0010808	Protruding tongue	skos:closeMatch	1	MP:0009908	protruding tongue	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-31	CHARGE model not Chd7| MP specifies 'beyond oral cavity' HPO ' beyond the alveolar ridges or teeth at rest' so I called these close
+HP:0012757	Abnormal neuron morphology	skos:broadMatch	1	MP:0009937	abnormal neuron differentiation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0025057	Abnormality of olfactory lobe morphology	skos:exactMatch	1	MP:0009944	abnormal olfactory lobe morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0002334	Abnormal cerebellar vermis morphology	skos:broadMatch	1	MP:0009957	abnormal cerebellum vermis lobule morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0009959	abnormal cerebellar hemisphere morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0009963	abnormal cerebellum hemisphere lobule morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0009991	abnormal cerebellum vermis lobule IV morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0013616	decreased volumetric bone mineral density	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0009992	abnormal cerebellum vermis lobule IX morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0009993	abnormal cerebellum vermis lobule V morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0009996	abnormal cerebellum vermis lobule VIII morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:relatedMatch	0.9	MP:0010005	abnormal lobule simplex morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7| this structure does not exist in humans so calling this related rather than broad
+HP:0041079	Decreased body fat percentage	skos:relatedMatch	1	MP:0010025	decreased total body fat amount	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0012754	CNS hypermyelination	skos:narrowMatch	1	MP:0010050	hypermyelination	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0030173	Peripheral hypermyelination	skos:narrowMatch	1	MP:0010050	hypermyelination	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0003690	Limb muscle weakness	skos:relatedMatch	1	MP:0010053	decreased grip strength	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0040326	Hypoplasia of the olfactory bulb	skos:exactMatch	0.9	MP:0010059	olfactory bulb hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	"Chd7|uncertainty and noise due to difference in definition and use of hypoplasia in the two ontologies, often used in HPO as synonymous with 'small'"
+HP:0001877	Abnormal erythrocyte morphology	skos:broadMatch	1	MP:0010068	decreased red blood cell distribution width	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7|HPO term has the child increased width but no term for decreased width 
+HP:0002917	Hypomagnesemia	skos:exactMatch	1	MP:0010093	decreased circulating magnesium level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0004370	Abnormality of temperature regulation	skos:broadMatch	1	MP:0010165	abnormal response to stress-induced hyperthermia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0012638	Abnormal nervous system physiology	skos:broadMatch	1	MP:0010205	abnormal oligodendrocyte apoptosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0010979	Abnormality of lipoprotein cholesterol concentration	skos:narrowMatch	1	MP:0010330	abnormal circulating lipoprotein level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0011555	Double inlet left ventricle	skos:exactMatch	1	MP:0010433	double inlet heart left ventricle	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0002624	Abnormal venous morphology	skos:broadMatch	1	MP:0010453	abnormal coronary vein morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0001660	Truncus arteriosus	skos:narrowMatch	1	MP:0010454	abnormal truncus arteriosus septation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0011604	Aortopulmonary window	skos:exactMatch	1	MP:0010455	aortopulmonary window	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0012305	Coarctation of the descending aortic arch	skos:narrowMatch	1	MP:0010526	aortic arch coarctation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0001713	Abnormal cardiac ventricle morphology	skos:broadMatch	1	MP:0010556	thin ventricle myocardium compact layer	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0006705	Abnormal atrioventricular valve morphology	skos:broadMatch	1	MP:0010607	common atrioventricular valve	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0000480	Retinal coloboma	skos:exactMatch	0.9	MP:0010715	retina coloboma	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	CHARGE model not Chd7| uncertainty as MP specifies this is congential and the HPO does not
+HP:0002752	Sparse bone trabeculae	skos:relatedMatch	0.8	MP:0010869	decreased bone trabecula number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	"Chd7| HPO term lacks a definition but eq uses PATO sparse - defined as 'scattered; spread irregularly, and at a distance from each other' so it seems to me that these are related but not close or exact"
+HP:0030313	Abnormal periosteum morphology	skos:broadMatch	1	MP:0010973	increased periosteum thickness	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0003811	Neonatal lethal	skos:relatedMatch	1	MP:0011089	"perinatal lethality, complete penetrance"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0034241	Prenatal death	skos:relatedMatch	1	MP:0011092	"embryonic lethality, complete penetrance"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0034241	Prenatal death	skos:relatedMatch	1	MP:0011098	"embryonic lethality during organogenesis, complete penetrance"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0034241	Prenatal death	skos:relatedMatch	1	MP:0011099	"lethality throughout fetal growth and development, complete penetrance"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	CHARGE model not Chd7
+HP:0034241	Prenatal death	skos:relatedMatch	1	MP:0011108	"embryonic lethality during organogenesis, incomplete penetrance"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0034241	Prenatal death	skos:relatedMatch	1	MP:0011109	"lethality throughout fetal growth and development, incomplete penetrance"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0005105	Abnormal nasal morphology	skos:broadMatch	1	MP:0011281	abnormal olfactory epithelium cilium morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0034190	Abnormal fetal cardiovascular physiology	skos:broadMatch	1	MP:0011390	abnormal fetal cardiomyocyte physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0034190	Abnormal fetal cardiovascular physiology	skos:broadMatch	1	MP:0011395	decreased fetal cardiomyocyte proliferation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0011420	Age of death	skos:relatedMatch	1	MP:0011400	"lethality, complete penetrance"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0011613	Interrupted aortic arch type B	skos:exactMatch	1	MP:0011659	"interrupted aortic arch, type b"	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0012447	Abnormal myelination	skos:broadMatch	1	MP:0011731	decreased myelin sheath thickness	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0000240	Abnormality of skull size	skos:broadMatch	1	MP:0011861	increased cranium height	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0004463	Absent brainstem auditory responses	skos:narrowMatch	1	MP:0011967	increased or absent threshold for auditory brainstem response	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0012638	Abnormal nervous system physiology	skos:broadMatch	1	MP:0012020	abnormal olfactory epithelium physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0012757	Abnormal neuron morphology	skos:broadMatch	1	MP:0012203	abnormal neuronal stem cell morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0031422	Abnormal cerebellar cortex morphology	skos:broadMatch	1	MP:0012451	abnormal retrosplenial granular cortex morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0012502	Abnormality of the internal capsule	skos:broadMatch	1	MP:0012462	decreased brain internal capsule size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0010662	Abnormality of the diencephalon	skos:broadMatch	1	MP:0012481	increased habenula size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-01	Chd7
+HP:0045005	Neural tube defect	skos:broadMatch	1	MP:0012703	decreased embryonic neuroepithelium thickness	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0430021	Abnormal common carotid artery morphology	skos:exactMatch	1	MP:0012729	abnormal common carotid artery morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0033334	Abnormal embryonic development	skos:broadMatch	1	MP:0012741	decreased neural crest cell proliferation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	CHARGE model not Chd7
+HP:0033334	Abnormal embryonic development	skos:broadMatch	1	MP:0012744	increased neural crest cell apoptosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	CHARGE model not Chd7
+HP:0011747	Abnormality of the anterior pituitary	skos:broadMatch	1	MP:0013350	Rathke's pouch hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0003429	CNS hypomyelination	skos:narrowMatch	1	MP:0013438	dysmyelination	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0007182	Peripheral hypomyelination	skos:narrowMatch	1	MP:0013438	dysmyelination	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	
+HP:0001097	Keratoconjunctivitis sicca	skos:closeMatch	0.8	MP:0013466	keratoconjunctivitis sicca	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	"Chd7| uncertainty as the MP term is defined as inflamation caused by eye dryness which, in turn, is caused by either decreased tear production or increased tear film evaporation while the HPO term is defined as eye dryness with no mention of inflammation"
+HP:0031066	Abnormal ovarian physiology	skos:broadMatch	1	MP:0013508	increased granulosa cell apoptosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0003103	Abnormal cortical bone morphology	skos:broadMatch	1	MP:0013624	decreased femur compact bone thickness	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0100671	Abnormal trabecular bone morphology	skos:broadMatch	1	MP:0013630	increased bone trabecular spacing	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0000174	Abnormal palate morphology	skos:broadMatch	1	MP:0013767	decreased palatal rugae number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0012372	Abnormal eye morphology	skos:broadMatch	1	MP:0013820	absent optic cup	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0041079	Decreased body fat percentage	skos:relatedMatch	1	MP:0014143	decreased body fat mass	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0004349	Reduced bone mineral density	skos:broadMatch	1	MP:0020010	decreased bone mineral density of femur	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	CHARGE model not Chd7
+HP:0004349	Reduced bone mineral density	skos:relatedMatch	1	MP:0020137	decreased bone mineralization	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0012757	Abnormal neuron morphology	skos:broadMatch	1	MP:0020348	decreased olfactory sensory neuron number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0008609	Morphological abnormality of the middle ear	skos:broadMatch	1	MP:0020900	abnormal middle ear epithelium morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0008609	Morphological abnormality of the middle ear	skos:broadMatch	1	MP:0020903	increased middle ear goblet cell number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0004349	Reduced bone mineral density	skos:broadMatch	1	MP:0021184	decreased bone mineral density of humerus	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	CHARGE model not Chd7
+HP:0005561	Abnormality of bone marrow cell morphology	skos:broadMatch	1	MP:0030009	increased bone marrow adipose tissue amount	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0000321	Square face	skos:exactMatch	1	MP:0030073	square face	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	CHARGE model not Chd7
+HP:0001367	Abnormal joint morphology	skos:broadMatch	1	MP:0030109	abnormal incudomalleolar joint morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0008628	Abnormality of the stapes	skos:broadMatch	1	MP:0030127	small stapes	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0011453	Abnormality of the incus	skos:broadMatch	1	MP:0030394	abnormal incus short process morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0011453	Abnormality of the incus	skos:broadMatch	1	MP:0030396	abnormal incus long process morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0008628	Abnormality of the stapes	skos:broadMatch	1	MP:0030402	abnormal stapes head morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0008628	Abnormality of the stapes	skos:broadMatch	1	MP:0030405	small stapes obturator foramen	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0008628	Abnormality of the stapes	skos:broadMatch	1	MP:0030407	abnormal stapes crus morpholgy	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0040099	Abnormality of the round window	skos:broadMatch	1	MP:0030411	decreased round window size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-05	Chd7
+HP:0011912	Abnormality of the glenoid fossa	skos:exactMatch	0.9	MP:0030831	abnormal glenoid fossa morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-06	Chd7| uncertainty since the term label and definition do not specify 'morphology' but placement is on the morphology branch
+HP:0010948	Abnormal fetal cardiovascular morphology	skos:broadMatch	1	MP:0030992	atrioventricular cushion hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-06	Chd7
+HP:0031065	Abnormal ovarian morphology	skos:broadMatch	0.8	MP:0031239	increased atretic ovarian follicle number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-06	"Chd7| the only ovarian follicle number terms in HPO are for antral follicles and are under physiology, MP puts these under morphology and has many more count terms. I've chosen the morphology term in HPO in keeping with the MP placement"
+HP:0003307	Hyperlordosis	skos:narrowMatch	0.9	MP:0031253	lordokyphosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-06	CHARGE model not Chd7| some uncertainty as the definition in MP does not specify spinal location while the HP definition does
+HP:0002808	Kyphosis	skos:narrowMatch	0.9	MP:0031253	lordokyphosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-06	CHARGE model not Chd7| some uncertainty as the definition in MP does not specify spinal location while the HP definition does
+HP:0031065	Abnormal ovarian morphology	skos:broadMatch	0.8	MP:0031381	decreased secondary ovarian follicle number	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-06	"Chd7| the only ovarian follicle number terms in HPO are for antral follicles and are under physiology, MP puts these under morphology and has many more count terms. I've chosen the morphology term in HPO in keeping with the MP placement"
+HP:0000752	Hyperactivity	skos:broadMatch	1	MP:0031391	increased locomotor activity	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-09-06	Chd7
+HP:0000394	Lop ear	skos:narrowMatch	1	MP:0000022	abnormal ear shape	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0011381	Aplasia of the semicircular canal	skos:exactMatch	1	MP:0000036	absent semicircular canals	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0000772	Abnormal rib morphology	skos:exactMatch	1	MP:0000150	abnormal rib morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE | note the HPO definition is broader 'An anomaly of the rib' than just morphology but based on placement I'm calling these exact
+HP:0002623	Overriding aorta	skos:exactMatch	1	MP:0000273	overriding aortic valve	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000160	Narrow mouth	skos:narrowMatch	1	MP:0000452	abnormal mouth morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	CHARGE | ticket #3790
+HP:0003974	Absent radius	skos:exactMatch	0.9	MP:0000553	absent radius	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	"CHARGE| the MP term is somewhat ambiguous in definition, typically we mean absent as total absence which would be closer to the HPO term Bilateral radial aplasia but the MP does not have a term for decreased radius number and there is at least one case where unilateral absence has been annotated to the absent term"
+HP:0002992	Abnormality of tibia morphology	skos:exactMatch	1	MP:0000558	abnormal tibia morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0010443	Bifid femur	skos:narrowMatch	1	MP:0000559	abnormal femur morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0001018	Abnormal palmar dermatoglyphics	skos:narrowMatch	1	MP:0000572	abnormal autopod morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0000834	Abnormality of the adrenal glands	skos:broadMatch	1	MP:0000639	abnormal adrenal gland morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0010515	Aplasia/Hypoplasia of the thymus	skos:broadMatch	1	MP:0000705	athymia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-20	CHARGE
+HP:0001305	Dandy-Walker malformation	skos:narrowMatch	0.9	MP:0000849	abnormal cerebellum morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE | some uncertainty since the malformation involves more than just the cerebellum but the HPO definition and placement indicate the cerebellum cyst is the key part
+HP:0001291	Abnormal cranial nerve morphology	skos:exactMatch	1	MP:0001056	abnormal cranial nerve morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000625	Eyelid coloboma	skos:narrowMatch	1	MP:0001340	abnormal eyelid morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0011968	Feeding difficulties	skos:narrowMatch	0.9	MP:0001431	abnormal eating behavior	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE| the MP has this under behavior while the HPO term is under digestive system/abdominal symptoms suggesting there may be some difference in the intent of these terms
+HP:0010978	Abnormality of immune system physiology	skos:exactMatch	1	MP:0001790	abnormal immune system physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0010515	Aplasia/Hypoplasia of the thymus	skos:broadMatch	1	MP:0001823	thymus hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-20	CHARGE
+HP:0002093	Respiratory insufficiency	skos:narrowMatch	1	MP:0001943	abnormal respiration	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE | HPO term lacks a text definition based on child terms I went up to abnormal respiration to cover all children; ticket #3794
+HP:0000504	Abnormality of vision	skos:exactMatch	1	MP:0002090	abnormal vision	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE | ticket #3791
+HP:0008572	External ear malformation	skos:narrowMatch	1	MP:0002177	abnormal outer ear morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0011382	Hypoplasia of the semicircular canal	skos:narrowMatch	1	MP:0002428	abnormal semicircular canal morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0000742	Self-mutilation	skos:narrowMatch	1	MP:0002572	abnormal emotion/affect behavior	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE | mapping based on parents of HPO term
+HP:0000347	Micrognathia	skos:narrowMatch	1	MP:0002639	micrognathia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	"CHARGE | MP def  'abnormally reduced size of the jaws, especially of the mandible' HPO term is defined as 'Developmental hypoplasia of the mandible' thus despite sharing the same label the MP term is broader than the HPO term"
+HP:0009556	Absent tibia	skos:exactMatch	1	MP:0002728	absent tibia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000834	Abnormality of the adrenal glands	skos:broadMatch	1	MP:0002909	abnormal adrenal gland physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0002410	Aqueductal stenosis	skos:exactMatch	1	MP:0002958	cerebral aqueductal stenosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0003241	External genital hypoplasia	skos:relatedMatch	1	MP:0003126	abnormal external female genitalia morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	
+HP:0100736	Abnormal soft palate morphology	skos:exactMatch	0.9	MP:0003154	abnormal soft palate morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE| presence of the child term 'Velopharyngeal insufficiency' causes some uncertainty as this seems more like a physiology term
+HP:0011382	Hypoplasia of the semicircular canal	skos:broadMatch	1	MP:0003162	decreased lateral semicircular canal size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0011382	Hypoplasia of the semicircular canal	skos:broadMatch	1	MP:0003164	decreased posterior semicircular canal size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0011382	Hypoplasia of the semicircular canal	skos:broadMatch	1	MP:0003166	decreased superior semicircular canal size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0002139	Arrhinencephaly	skos:narrowMatch	1	MP:0003232	abnormal forebrain development	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	"CHARGE | HPO term lacks definition, based on Googling the definition seems to be the absence of the olfactory bulbs and tracts, this would suggest this should not be a child of anencephaly - HPO ticket #9918"
+HP:0000830	Anterior hypopituitarism	skos:exactMatch	0.9	MP:0003348	hypopituitarism	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	"CHARGE | MP defines this ""reduction or cessation of secretion of one or more hormones from the anterior pituitary gland"" HPO defines this as 'condition of reduced function of the anterior pituitary gland characterized by decreased secretion of one or more of the pituitary hormones' Note HPO has a separate term for hypopituitarism that has anterior hypo.. as a child but this term is a child of Abnormality of the anterior pituitary and lacks a definition so I'm not sure what the distinction between the two HPO terms. This is another case where the MP has this under physiology and HPO has it under morphology, hence the uncertainty "
+HP:0008213	Gonadotropin deficiency	skos:narrowMatch	1	MP:0003348	hypopituitarism	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0008213	Gonadotropin deficiency	skos:relatedMatch	1	MP:0003363	decreased circulating gonadotropin level	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE  | the HPO term is defined in terms of secretion thus the MP term about level is related since lowered secretion could cause the lower level 
+HP:0000829	Hypoparathyroidism	skos:closeMatch	0.9	MP:0003433	decreased activity of parathyroid	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	"CHARGE | MP defines this as reduced function of the parathyroid gland, HPO defines this as deficiency of parathyroid hormone; there is potential for subtle distinction but I think these are very close "
+HP:0002139	Arrhinencephaly	skos:relatedMatch	1	MP:0003451	absent olfactory bulb	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000860	Parathyroid hypoplasia	skos:exactMatch	1	MP:0003494	parathyroid hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0000066	Labial hypoplasia	skos:closeMatch	0.9	MP:0003513	small labia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	CHARGE
+HP:0009906	Aplasia/Hypoplasia of the earlobes	skos:broadMatch	1	MP:0003678	absent ear lobes	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0009906	Aplasia/Hypoplasia of the earlobes	skos:broadMatch	1	MP:0003679	ear lobe hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0004058	Hand monodactyly	skos:narrowMatch	1	MP:0003800	monodactyly	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0001561	Polyhydramnios	skos:exactMatch	1	MP:0004020	polyhydramnios	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0001360	Holoprosencephaly	skos:exactMatch	1	MP:0005157	holoprosencephaly	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000567	Chorioretinal coloboma	skos:narrowMatch	1	MP:0005262	coloboma	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0000589	Coloboma	skos:exactMatch	1	MP:0005262	coloboma	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0000272	Malar flattening	skos:narrowMatch	1	MP:0005270	abnormal zygomatic bone morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	CHARGE
+HP:0000478	Abnormality of the eye	skos:narrowMatch	1	MP:0005391	vision/eye phenotype	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE | the MP term is also used for unexpected 'normal' eye phenotypes
+HP:0000044	Hypogonadotropic hypogonadism	skos:narrowMatch	1	MP:0005647	abnormal sex gland physiology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	CHARGE | ticket #3778
+HP:0001671	Abnormal cardiac septum morphology	skos:exactMatch	1	MP:0006113	abnormal heart septum morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	"CHARGE| add synonym, note MP has a child term for aorticopulmonary septum that by the text definition seems like it might not fit but based on the UBERON terms is considered a cardiac septum, both MP and HP use caridac septum in the EQ"
+HP:0000410	Mixed hearing impairment	skos:exactMatch	1	MP:0006327	mixed hearing impairment	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE | probably worth reviewing the hearing loss annotations as I suspect we may have annotations made to both sensineural and conductive rahter than to mixed
+HP:0002025	Anal stenosis	skos:exactMatch	1	MP:0009052	anal stenosis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0003241	External genital hypoplasia	skos:broadMatch	1	MP:0009203	external male genitalia hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000008	Abnormal morphology of female internal genitalia	skos:exactMatch	1	MP:0009209	abnormal internal female genitalia morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-17	CHARGE
+HP:0004935	Pulmonary artery atresia	skos:closeMatch	1	MP:0010521	absent pulmonary artery	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0005113	Aortic arch aneurysm	skos:narrowMatch	1	MP:0010575	aortic arch dilation	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0030732	Dysplastic tricuspid valve	skos:narrowMatch	1	MP:0002624	abnormal tricuspid valve morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	"CHARGE| the HPO term is defined as ""A congenital malformation of the tricuspid valve characterized by leaflet deformation"" and the MP cusp term has 'leaflet' as a synonym. But the HPO term has a long note that specifies the different types of dysplasia some that involve more than the leaflets so I've backed this off to the parent MP term of tricuspid valve"
+HP:0000612	Iris coloboma	skos:exactMatch	1	MP:0010714	iris coloboma	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0000480	Retinal coloboma	skos:exactMatch	1	MP:0010715	retina coloboma	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0009778	Short thumb	skos:narrowMatch	1	MP:0010772	abnormal pollex morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000632	Lacrimation abnormality	skos:exactMatch	1	MP:0020218	abnormal tear production	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0001270	Motor delay	skos:narrowMatch	1	MP:0021165	behavioral developmental delay	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE | ticket #3792
+HP:0005280	Depressed nasal bridge	skos:exactMatch	1	MP:0030034	depressed nasal bridge	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0000275	Narrow face	skos:narrowMatch	1	MP:0030071	abnormal face shape	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0000321	Square face	skos:exactMatch	1	MP:0030073	square face	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-18	CHARGE
+HP:0010669	Hypoplasia of the zygomatic bone	skos:exactMatch	1	MP:0030112	zygomatic bone hypoplasia	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-20	CHARGE
+HP:0010628	Facial palsy	skos:relatedMatch	1	MP:0030141	facial paralysis	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-20	CHARGE
+HP:0010751	Dimple chin	skos:narrowMatch	1	MP:0030243	abnormal chin morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0200021	Down-sloping shoulders	skos:relatedMatch	1	MP:0030816	abnormal shoulder joint morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-08-01	CHARGE
+HP:0003048	Radial head subluxation	skos:narrowMatch	1	MP:0030882	abnormal radius head morphology	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE
+HP:0003022	Hypoplasia of the ulna	skos:closeMatch	1	MP:0030900	decreased ulna size	semapv:ManualMappingCuration	orcid:0000-0003-4606-0597	2023-07-19	CHARGE


### PR DESCRIPTION
Adding MP-HP mappings for phenotypes related to CHARGE syndrome. Phenotypes come from both HPO human phenotypes and from MGI mouse models.
Adds another ~360 mappings 